### PR TITLE
Boxing day

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ License
 
 Licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE][apc] or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT][mit] or http://opensource.org/licenses/MIT)
+ * Apache License, Version 2.0, ([LICENSE-APACHE][license-url-ap2] or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT][license-url-mit] or http://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/src/harsh.rs
+++ b/src/harsh.rs
@@ -15,11 +15,11 @@ use {
 /// meaning just one can be used pretty much through your system.
 #[derive(Clone, Debug)]
 pub struct Harsh {
-    salt: Vec<u8>,
-    alphabet: Vec<u8>,
-    separators: Vec<u8>,
+    salt: Box<[u8]>,
+    alphabet: Box<[u8]>,
+    separators: Box<[u8]>,
     hash_length: usize,
-    guards: Vec<u8>,
+    guards: Box<[u8]>,
 }
 
 impl Harsh {
@@ -234,11 +234,11 @@ impl HarshFactory {
         let guards = guards(&mut alphabet, &mut separators);
 
         Ok(Harsh {
-            salt: salt,
-            alphabet: alphabet,
-            separators: separators,
+            salt: salt.into_boxed_slice(),
+            alphabet: alphabet.into_boxed_slice(),
+            separators: separators.into_boxed_slice(),
             hash_length: self.hash_length,
-            guards: guards,
+            guards: guards.into_boxed_slice(),
         })
     }
 }


### PR DESCRIPTION
According to @Dr-Emann, this shaves off the capacity field from things line vectors and strings. I realize that's just one usize value, but... meh. :)

The good gentleman also makes a point regarding accidentally changing the size of the value. I figure that's true, but none of the methods take `&mut self`, so that's not technically feasible to begin with.

I also got lazy and rolled in a fix for the license links in the readme.