### PR TITLE
Include JS tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ let numbers = hashids.decode(id).unwrap(); // [1, 2, 3]
 Pass a project name to make your ids unique:
 
 ```rust
-let harsh = HarshFactory::new().with_salt("My Project").init().unwrap();
+let harsh = HarshFactory::new().salt("My Project").init().unwrap();
 let id = harsh.encode(&[1, 2, 3]).unwrap(); // "Z4UrtW"
 
-let harsh = HarshFactory::new().with_salt("My Other Project").init().unwrap();
+let harsh = HarshFactory::new().salt("My Other Project").init().unwrap();
 let id = harsh.encode(&[1, 2, 3]).unwrap(); // "gPUasb"
 ```
 
@@ -35,14 +35,14 @@ Note that ids are only padded to fit **at least** a certain length. It doesn't m
 let harsh = HarshFactory::new().init().unwrap(); // no padding
 let id = harsh.encode(&[1]).unwrap() // "jR"
 
-let harsh = HarshFactory::new().with_hash_length(10).init().unwrap(); // pad to length 10
+let harsh = HarshFactory::new().length(10).init().unwrap(); // pad to length 10
 let id = harsh.encode(&[1]).unwrap() // "VolejRejNm"
 ```
 
 **Pass a custom alphabet:**
 
 ```rust
-let harsh = HarshFactory::new().with_alphabet("abcdefghijklmnopqrstuvwxyz").init().unwrap(); // all lowercase
+let harsh = HarshFactory::new().alphabet("abcdefghijklmnopqrstuvwxyz").init().unwrap(); // all lowercase
 let id = harsh.encode(&[1, 2, 3]).unwrap(); // "mdfphx"
 ```
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@ use std::fmt;
 pub type Result<T> = ::std::result::Result<T, Error>;
 
 const ALPHABET_LENGTH_MESSAGE: &'static str = "The provided alphabet does not contain enough unique characters";
+const ILLEGAL_CHARACTER_MESSAGE: &'static str = "The provided alphabet contains an illegal character";
 const SEPARATOR_MESSAGE: &'static str = "The provided separators contain a character not found in the alphabet";
 
 /// Represents potential errors encountered during `Harsh` initialization.
@@ -11,6 +12,9 @@ const SEPARATOR_MESSAGE: &'static str = "The provided separators contain a chara
 pub enum Error {
     /// Error returned when the provided alphabet has insufficient distinct elements
     AlphabetLength,
+
+    /// Provided alphabet contains an illegal character
+    IllegalCharacter(char),
 
     /// Error returned when a separator character is not found in the alphabet
     Separator,
@@ -20,6 +24,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::AlphabetLength => write!(f, "{}", ALPHABET_LENGTH_MESSAGE),
+            Error::IllegalCharacter(c) => write!(f, "{} ({})", ILLEGAL_CHARACTER_MESSAGE, c),
             Error::Separator => write!(f, "{}", SEPARATOR_MESSAGE),
         }
     }
@@ -29,6 +34,7 @@ impl ErrorTrait for Error {
     fn description(&self) -> &str {
         match *self {
             Error::AlphabetLength => ALPHABET_LENGTH_MESSAGE,
+            Error::IllegalCharacter(_) => ILLEGAL_CHARACTER_MESSAGE,
             Error::Separator => SEPARATOR_MESSAGE,
         }
     }

--- a/src/harsh.rs
+++ b/src/harsh.rs
@@ -189,7 +189,7 @@ impl HarshFactory {
     ///
     /// Note that this salt will be converted into a `[u8]` before use, meaning 
     /// that multi-byte utf8 character values should be avoided. 
-    pub fn with_salt<T: Into<Vec<u8>>>(mut self, salt: T) -> HarshFactory {
+    pub fn salt<T: Into<Vec<u8>>>(mut self, salt: T) -> HarshFactory {
         self.salt = Some(salt.into());
         self
     }
@@ -198,7 +198,7 @@ impl HarshFactory {
     ///
     /// Note that this alphabet will be converted into a `[u8]` before use, meaning
     /// that multi-byte utf8 character values should be avoided.
-    pub fn with_alphabet<T: Into<Vec<u8>>>(mut self, alphabet: T) -> HarshFactory {
+    pub fn alphabet<T: Into<Vec<u8>>>(mut self, alphabet: T) -> HarshFactory {
         self.alphabet = Some(alphabet.into());
         self
     }
@@ -207,7 +207,7 @@ impl HarshFactory {
     ///
     /// Note that these separators will be converted into a `[u8]` before use, 
     /// meaning that multi-byte utf8 character values should be avoided.
-    pub fn with_separators<T: Into<Vec<u8>>>(mut self, separators: T) -> HarshFactory {
+    pub fn separators<T: Into<Vec<u8>>>(mut self, separators: T) -> HarshFactory {
         self.separators = Some(separators.into());
         self
     }
@@ -215,7 +215,7 @@ impl HarshFactory {
     /// Provides a minimum hash length.
     ///
     /// Keep in mind that hashes produced may be longer than this length.
-    pub fn with_hash_length(mut self, hash_length: usize) -> HarshFactory {
+    pub fn length(mut self, hash_length: usize) -> HarshFactory {
         self.hash_length = hash_length;
         self
     }
@@ -371,7 +371,7 @@ mod tests {
     #[test]
     fn can_encode() {
         let harsh = HarshFactory::new()
-            .with_salt("this is my salt")
+            .salt("this is my salt")
             .init()
             .expect("failed to initialize harsh");
 
@@ -382,8 +382,8 @@ mod tests {
     #[test]
     fn can_encode_with_guards() {
         let harsh = HarshFactory::new()
-            .with_salt("this is my salt")
-            .with_hash_length(8)
+            .salt("this is my salt")
+            .length(8)
             .init()
             .expect("failed to initialize harsh");
 
@@ -393,8 +393,8 @@ mod tests {
     #[test]
     fn can_encode_with_padding() {
         let harsh = HarshFactory::new()
-            .with_salt("this is my salt")
-            .with_hash_length(12)
+            .salt("this is my salt")
+            .length(12)
             .init()
             .expect("failed to initialize harsh");
 
@@ -404,7 +404,7 @@ mod tests {
     #[test]
     fn can_decode() {
         let harsh = HarshFactory::new()
-            .with_salt("this is my salt")
+            .salt("this is my salt")
             .init()
             .expect("failed to initialize harsh");
 
@@ -415,8 +415,8 @@ mod tests {
     #[test]
     fn can_decode_with_guards() {
         let harsh = HarshFactory::new()
-            .with_salt("this is my salt")
-            .with_hash_length(8)
+            .salt("this is my salt")
+            .length(8)
             .init()
             .expect("failed to initialize harsh");
 
@@ -426,8 +426,8 @@ mod tests {
     #[test]
     fn can_decode_with_padding() {
         let harsh = HarshFactory::new()
-            .with_salt("this is my salt")
-            .with_hash_length(12)
+            .salt("this is my salt")
+            .length(12)
             .init()
             .expect("failed to initialize harsh");
 
@@ -437,7 +437,7 @@ mod tests {
     #[test]
     fn can_encode_hex() {
         let harsh = HarshFactory::new()
-            .with_salt("this is my salt")
+            .salt("this is my salt")
             .init()
             .expect("failed to initialize harsh");
 
@@ -458,8 +458,8 @@ mod tests {
     #[test]
     fn can_encode_hex_with_guards() {
         let harsh = HarshFactory::new()
-            .with_salt("this is my salt")
-            .with_hash_length(10)
+            .salt("this is my salt")
+            .length(10)
             .init()
             .expect("failed to initialize harsh");
             
@@ -469,8 +469,8 @@ mod tests {
     #[test]
     fn can_encode_hex_with_padding() {
         let harsh = HarshFactory::new()
-            .with_salt("this is my salt")
-            .with_hash_length(12)
+            .salt("this is my salt")
+            .length(12)
             .init()
             .expect("failed to initialize harsh");
             
@@ -480,7 +480,7 @@ mod tests {
     #[test]
     fn can_decode_hex() {
         let harsh = HarshFactory::new()
-            .with_salt("this is my salt")
+            .salt("this is my salt")
             .init()
             .expect("failed to initialize harsh");
 
@@ -501,8 +501,8 @@ mod tests {
     #[test]
     fn can_decode_hex_with_guards() {
         let harsh = HarshFactory::new()
-            .with_salt("this is my salt")
-            .with_hash_length(10)
+            .salt("this is my salt")
+            .length(10)
             .init()
             .expect("failed to initialize harsh");
             
@@ -512,8 +512,8 @@ mod tests {
     #[test]
     fn can_decode_hex_with_padding() {
         let harsh = HarshFactory::new()
-            .with_salt("this is my salt")
-            .with_hash_length(12)
+            .salt("this is my salt")
+            .length(12)
             .init()
             .expect("failed to initialize harsh");
             
@@ -523,7 +523,7 @@ mod tests {
     #[test]
     fn can_encode_with_custom_alphabet() {
         let harsh = HarshFactory::new()
-            .with_alphabet("abcdefghijklmnopqrstuvwxyz")
+            .alphabet("abcdefghijklmnopqrstuvwxyz")
             .init()
             .expect("failed to initialize harsh");
 
@@ -533,7 +533,7 @@ mod tests {
     #[test]
     fn can_decode_with_custom_alphabet() {
         let harsh = HarshFactory::new()
-            .with_alphabet("abcdefghijklmnopqrstuvwxyz")
+            .alphabet("abcdefghijklmnopqrstuvwxyz")
             .init()
             .expect("failed to initialize harsh");
 

--- a/src/harsh.rs
+++ b/src/harsh.rs
@@ -94,8 +94,8 @@ impl Harsh {
     }
 
     /// Decodes a single hashid into a slice of `u64` values.
-    pub fn decode(&self, value: &str) -> Option<Vec<u64>> {
-        let mut value = value.as_bytes().to_vec();
+    pub fn decode<T: AsRef<str>>(&self, value: T) -> Option<Vec<u64>> {
+        let mut value = value.as_ref().as_bytes().to_vec();
 
         if let Some(guard_idx) = value.iter().rposition(|u| self.guards.contains(u)) {
             value.truncate(guard_idx);

--- a/src/harsh.rs
+++ b/src/harsh.rs
@@ -163,6 +163,12 @@ impl Harsh {
     }
 }
 
+impl Default for Harsh {
+    fn default() -> Harsh {
+        HarshFactory::new().init().unwrap()
+    }
+}
+
 /// Factory used to create a new `Harsh` instance.
 ///
 /// Note that this factory will be consumed upon initialization.
@@ -367,6 +373,11 @@ fn unhash(input: &[u8], alphabet: &[u8]) -> u64 {
 #[cfg(test)]
 mod tests {
     use harsh::{self, HarshFactory};
+
+    #[test]
+    fn harsh_default_does_not_panic() {
+        harsh::Harsh::default();
+    }
 
     #[test]
     fn can_encode() {

--- a/src/harsh.rs
+++ b/src/harsh.rs
@@ -269,6 +269,10 @@ fn unique_alphabet(alphabet: &Option<Vec<u8>>) -> Result<Vec<u8>> {
             let mut ret = Vec::new();
 
             for &item in alphabet {
+                if item == b' ' {
+                    return Err(Error::IllegalCharacter(item as char));
+                }
+
                 if !reg.contains(&item) {
                     ret.push(item);
                     reg.insert(item);

--- a/src/harsh.rs
+++ b/src/harsh.rs
@@ -106,7 +106,7 @@ impl Harsh {
             Some(guard_idx) => &value[(guard_idx + 1)..],
         };
 
-        if value.is_empty() {
+        if value.len() < 2 {
             return None;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
+#[cfg(test)] mod tests;
+
 mod error;
 mod harsh;
 

--- a/src/tests/bad_input.rs
+++ b/src/tests/bad_input.rs
@@ -1,0 +1,42 @@
+use harsh::{Harsh, HarshFactory};
+
+#[test]
+fn small_alphabet() {
+    assert!(
+        !HarshFactory::new().alphabet("1234567890").init().is_ok(),
+        "should throw an error with a small alphabet"
+    );
+}
+
+#[test]
+fn spaces_in_alphabet() {
+    assert!(
+        !HarshFactory::new().alphabet("a cdefghijklmnopqrstuvwxyz").init().is_ok(),
+        "should throw an error when alphabet includes spaces"
+    );
+}
+
+#[test]
+fn should_return_none_for_encoding_nothing() {
+    assert_eq!(None, Harsh::default().encode(&[]), "should return None when encoding an empty array");
+}
+
+#[test]
+fn should_return_none_for_decoding_nothing() {
+    assert_eq!(None, Harsh::default().decode(""), "should return None when decoding nothing");
+}
+
+#[test]
+fn should_return_none_for_decoding_invalid_id() {
+    assert_eq!(None, Harsh::default().decode("f"), "should return None when decoding an invalid id");
+}
+
+#[test]
+fn should_return_none_when_encoding_non_hex_input() {
+    assert_eq!(None, Harsh::default().encode_hex("z"), "should return None when hex-encoding non-hex input");
+}
+
+#[test]
+fn should_return_none_when_hex_decoding_invalid_id() {
+    assert_eq!(None, Harsh::default().decode_hex("f"), "should return None when hex-decoding an invalid id");
+}

--- a/src/tests/custom_alphabet.rs
+++ b/src/tests/custom_alphabet.rs
@@ -1,0 +1,41 @@
+use harsh::HarshFactory;
+
+const NUMBERS: [u64; 3] = [1, 2, 3];
+
+#[test]
+fn bad_alphabet() {
+    test_alphabet("cCsSfFhHuUiItT01", "should work with the worst alphabet");
+}
+
+#[test]
+fn separators_alphabet() {
+    test_alphabet("abdegjklCFHISTUc", "should work with half the alphabet being separators");
+}
+
+#[test]
+fn two_separators() {
+    test_alphabet("abdegjklmnopqrSF", "should work with exactly two separators");
+}
+
+#[test]
+fn no_separators() {
+    test_alphabet("abdegjklmnopqrvwxyzABDEGJKLMNOPQRVWXYZ1234567890", "should work with no separators");
+}
+
+#[test]
+fn long_alphabet() {
+    test_alphabet("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890`~!@#$%^&*()-_=+\\|'\";:/?.>,<{[}]", "should work with super-long alphabet");
+}
+
+#[test]
+fn weird_alphabet() {
+    test_alphabet("`~!@#$%^&*()-_=+\\|'\";:/?.>,<{[}]", "should work with a weird alphabet");
+}
+
+fn test_alphabet(alphabet: &str, message: &str) {
+    let harsh = HarshFactory::new().alphabet(alphabet).init().unwrap();
+    let encoded = harsh.encode(&NUMBERS).unwrap();
+    let decoded = harsh.decode(encoded).unwrap();
+
+    assert_eq!(NUMBERS, &decoded[..], "{}", message);
+}

--- a/src/tests/custom_params.rs
+++ b/src/tests/custom_params.rs
@@ -1,0 +1,28 @@
+use harsh::HarshFactory;
+
+const TEST_CASES: [(&'static str, &'static [u64]); 14] = [
+	("nej1m3d5a6yn875e7gr9kbwpqol02q", &[0]),
+	("dw1nqdp92yrajvl9v6k3gl5mb0o8ea", &[1]),
+	("onqr0bk58p642wldq14djmw21ygl39", &[928728]),
+	("18apy3wlqkjvd5h1id7mn5ore2d06b", &[1, 2, 3]),
+	("o60edky1ng3vl9hbfavwr5pa2q8mb9", &[1, 0, 0]),
+	("o60edky1ng3vlqfbfp4wr5pa2q8mb9", &[0, 0, 1]),
+	("qek2a08gpl575efrfd7yomj9dwbr63", &[0, 0, 0]),
+	("m3d5a6yn875rae8y81a94gr9kbwpqo", &[1000000000000]),
+	("1q3y98ln48w96kpo0wgk314w5mak2d", &[9007199254740991]),
+	("op7qrcdc3cgc2c0cbcrcoc5clce4d6", &[5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5]),
+	("5430bd2jo0lxyfkfjfyojej5adqdy4", &[10000000000, 0, 0, 0, 999999999999999]),
+	("aa5kow86ano1pt3e1aqm239awkt9pk380w9l3q6", &[9007199254740991, 9007199254740991, 9007199254740991]),
+	("mmmykr5nuaabgwnohmml6dakt00jmo3ainnpy2mk", &[1000000001, 1000000002, 1000000003, 1000000004, 1000000005]),
+	("w1hwinuwt1cbs6xwzafmhdinuotpcosrxaz0fahl", &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
+];
+
+#[test]
+fn custom_params() {
+    let harsh = HarshFactory::new().salt("this is my salt").length(30).alphabet("xzal86grmb4jhysfoqp3we7291kuct5iv0nd").init().unwrap();
+
+    for &(hash, values) in &TEST_CASES {
+		assert_eq!(hash, harsh.encode(values).unwrap());
+		assert_eq!(values, &harsh.decode(hash).unwrap()[..]);
+    }
+}

--- a/src/tests/custom_params_hex.rs
+++ b/src/tests/custom_params_hex.rs
@@ -1,0 +1,22 @@
+use harsh::HarshFactory;
+
+const TEST_CASES: [(&'static str, &'static str); 8] = [
+	("0dbq3jwa8p4b3gk6gb8bv21goerm96", "deadbeef"),
+	("190obdnk4j02pajjdande7aqj628mr", "abcdef123456"),
+	("a1nvl5d9m3yo8pj1fqag8p9pqw4dyl", "ABCDDD6666DDEEEEEEEEE"),
+	("1nvlml93k3066oas3l9lr1wn1k67dy", "507f1f77bcf86cd799439011"),
+	("mgyband33ye3c6jj16yq1jayh6krqjbo", "f00000fddddddeeeee4444444ababab"),
+	("9mnwgllqg1q2tdo63yya35a9ukgl6bbn6qn8", "abcdef123456abcdef123456abcdef123456"),
+	("edjrkn9m6o69s0ewnq5lqanqsmk6loayorlohwd963r53e63xmml29", "f000000000000000000000000000000000000000000000000000f"),
+	("grekpy53r2pjxwyjkl9aw0k3t5la1b8d5r1ex9bgeqmy93eata0eq0", "fffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+];
+
+#[test]
+fn custom_params_hex() {
+    let harsh = HarshFactory::new().salt("this is my salt").length(30).alphabet("xzal86grmb4jhysfoqp3we7291kuct5iv0nd").init().unwrap();
+
+    for &(hash, value) in &TEST_CASES {
+		assert_eq!(hash, harsh.encode_hex(value).unwrap(), "failed to encode \"{}\"", value);
+		assert_eq!(value.to_lowercase(), harsh.decode_hex(hash).unwrap(), "failed to decode \"{}\"", hash);
+    }
+}

--- a/src/tests/custom_salt.rs
+++ b/src/tests/custom_salt.rs
@@ -1,0 +1,30 @@
+use harsh::HarshFactory;
+
+#[test]
+fn empty_salt() {
+    test_salt("", "should work with ''");
+}
+
+#[test]
+fn spaces_salt() {
+    test_salt("   ", "should work with '   '");
+}
+
+#[test]
+fn ordinary_salt() {
+    test_salt("this is my salt", "should work with 'this is my salt'");
+}
+
+#[test]
+fn long_salt() {
+    test_salt("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890`~!@#$%^&*()-_=+\\|'\";:/?.>,<{[}]", "should work with a really long salt");
+}
+
+#[test]
+fn weird_salt() {
+    test_salt("`~!@#$%^&*()-_=+\\|'\";:/?.>,<{[}]", "should work with a weird salt")
+}
+
+fn test_salt(salt: &str, message: &str) {
+    assert!(HarshFactory::new().salt(salt).init().is_ok(), "{}", message); 
+}

--- a/src/tests/default_params.rs
+++ b/src/tests/default_params.rs
@@ -1,0 +1,28 @@
+use harsh::Harsh;
+
+const TEST_CASES: [(&'static str, &'static [u64]); 14] = [
+    ("gY", &[0]),
+    ("jR", &[1]),
+    ("R8ZN0", &[928728]),
+    ("o2fXhV", &[1, 2, 3]),
+    ("jRfMcP", &[1, 0, 0]),
+    ("jQcMcW", &[0, 0, 1]),
+    ("gYcxcr", &[0, 0, 0]),
+    ("gLpmopgO6", &[1000000000000]),
+    ("lEW77X7g527", &[9007199254740991]),
+    ("BrtltWt2tyt1tvt7tJt2t1tD", &[5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5]),
+    ("G6XOnGQgIpcVcXcqZ4B8Q8B9y", &[10000000000, 0, 0, 0, 999999999999999]),
+    ("5KoLLVL49RLhYkppOplM6piwWNNANny8N", &[9007199254740991, 9007199254740991, 9007199254740991]),
+    ("BPg3Qx5f8VrvQkS16wpmwIgj9Q4Jsr93gqx", &[1000000001, 1000000002, 1000000003, 1000000004, 1000000005]),
+    ("1wfphpilsMtNumCRFRHXIDSqT2UPcWf1hZi3s7tN", &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
+];
+
+#[test]
+fn default_params() {
+    let harsh = Harsh::default();
+
+    for &(hash, values) in &TEST_CASES {
+		assert_eq!(hash, harsh.encode(values).unwrap());
+		assert_eq!(values, &harsh.decode(hash).unwrap()[..]);
+    }
+}

--- a/src/tests/default_params_hex.rs
+++ b/src/tests/default_params_hex.rs
@@ -1,0 +1,22 @@
+use harsh::Harsh;
+
+const TEST_CASES: [(&'static str, &'static str); 8] = [
+	("wpVL4j9g", "deadbeef"),
+	("kmP69lB3xv", "abcdef123456"),
+	("47JWg0kv4VU0G2KBO2", "ABCDDD6666DDEEEEEEEEE"),
+	("y42LW46J9luq3Xq9XMly", "507f1f77bcf86cd799439011"),
+	("m1rO8xBQNquXmLvmO65BUO9KQmj", "f00000fddddddeeeee4444444ababab"),
+	("wBlnMA23NLIQDgw7XxErc2mlNyAjpw", "abcdef123456abcdef123456abcdef123456"),
+	("VwLAoD9BqlT7xn4ZnBXJFmGZ51ZqrBhqrymEyvYLIP199", "f000000000000000000000000000000000000000000000000000f"),
+	("nBrz1rYyV0C0XKNXxB54fWN0yNvVjlip7127Jo3ri0Pqw", "fffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+];
+
+#[test]
+fn default_params_hex() {
+    let harsh = Harsh::default();
+    
+    for &(hash, value) in &TEST_CASES {
+		assert_eq!(hash, harsh.encode_hex(value).unwrap(), "failed to encode \"{}\"", value);
+		assert_eq!(value.to_lowercase(), harsh.decode_hex(hash).unwrap(), "failed to decode \"{}\"", hash);
+    }
+}

--- a/src/tests/min_length.rs
+++ b/src/tests/min_length.rs
@@ -1,0 +1,38 @@
+use harsh::HarshFactory;
+
+const NUMBERS: &'static [u64] = &[1, 2, 3];
+
+#[test]
+fn min_length_0() {
+    test_minimum_length(0);
+}
+
+#[test]
+fn min_length_1() {
+    test_minimum_length(1);
+}
+
+#[test]
+fn min_length_10() {
+    test_minimum_length(10);
+}
+
+#[test]
+fn min_length_999() {
+    test_minimum_length(999);
+}
+
+#[test]
+fn min_length_1000() {
+    test_minimum_length(1000);
+}
+
+fn test_minimum_length(n: usize) {
+    let harsh = HarshFactory::new().length(n).init().unwrap();
+
+    let hash = harsh.encode(NUMBERS).expect("failed to encode values");
+    let values = harsh.decode(&hash).expect("failed to decode hash");
+
+    assert_eq!(NUMBERS, &values[..], "encoding/decoding failed at length {}", n);
+    assert!(hash.len() >= n, "length too short for {}", n);
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,0 +1,8 @@
+mod bad_input;
+mod custom_alphabet;
+mod custom_params;
+mod custom_params_hex;
+mod custom_salt;
+mod default_params;
+mod default_params_hex;
+mod min_length;


### PR DESCRIPTION
Working to import tests from the following files in the original js repo:
 - [x] bad-input.js
 - [x] custom-alphabet.js
 - [x] custom-params-hex.js
 - [x] custom-params.js
 - [x] custom-salt.js
 - [x] default-params-hex.js
 - [x] default-params.js
 - [x] encode-types.js
 - [x] min-length.js

...I've also decided that the builder needed shorter method names. >.>