### PR TITLE
Prepare library for use on stable compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 cache: cargo
-rust: nightly
+rust: stable
 os:
     - linux
     - osx

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harsh"
-version = "0.1.0"
+version = "0.1.1"
 description = "Hashids implementation for Rust"
 readme = "README.md"
 repository = "https://github.com/archer884/harsh"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,5 @@
+format_strings = false
+reorder_imports = true
+fn_args_paren_newline = true
+#fn_args_layout = "Block"
+newline_style = "Unix"

--- a/src/harsh.rs
+++ b/src/harsh.rs
@@ -574,8 +574,8 @@ mod tests {
 
         let (alphabet, separators) = harsh::alphabet_and_separators(&Some(DEFAULT_SEPARATORS.to_vec()), DEFAULT_ALPHABET, b"this is my salt");
 
-        assert_eq!("AdG05N6y2rljDQak4xgzn8ZR1oKYLmJpEbVq3OBv9WwXPMe7", alphabet.iter().map(|&u| u as char).collect(): String);
-        assert_eq!("UHuhtcITCsFifS", separators.iter().map(|&u| u as char).collect(): String);
+        assert_eq!("AdG05N6y2rljDQak4xgzn8ZR1oKYLmJpEbVq3OBv9WwXPMe7", alphabet.iter().map(|&u| u as char).collect::<String>());
+        assert_eq!("UHuhtcITCsFifS", separators.iter().map(|&u| u as char).collect::<String>());
     }
 
     #[test]
@@ -585,14 +585,14 @@ mod tests {
         let separators = b"fu";
         let (alphabet, separators) = harsh::alphabet_and_separators(&Some(separators.to_vec()), DEFAULT_ALPHABET, b"this is my salt");
 
-        assert_eq!("4RVQrYM87wKPNSyTBGU1E6FIC9ALtH0ZD2Wxz3vs5OXJ", alphabet.iter().map(|&u| u as char).collect(): String);
-        assert_eq!("ufabcdeghijklmnopq", separators.iter().map(|&u| u as char).collect(): String);        
+        assert_eq!("4RVQrYM87wKPNSyTBGU1E6FIC9ALtH0ZD2Wxz3vs5OXJ", alphabet.iter().map(|&u| u as char).collect::<String>());
+        assert_eq!("ufabcdeghijklmnopq", separators.iter().map(|&u| u as char).collect::<String>());        
     }
 
     #[test]
     fn shuffle() {
         let salt = b"1234";
-        let mut values = "asdfzxcvqwer".bytes().collect(): Vec<_>;
+        let mut values = "asdfzxcvqwer".bytes().collect::<Vec<_>>();
         harsh::shuffle(&mut values, salt);
 
         assert_eq!("vdwqfrzcsxae", String::from_utf8_lossy(&values));

--- a/src/harsh.rs
+++ b/src/harsh.rs
@@ -230,7 +230,7 @@ impl HarshFactory {
     ///
     /// This method will consume the `HarshFactory`.
     pub fn init(self) -> Result<Harsh> {
-        let alphabet = unique_alphabet(&self.alphabet)?;
+        let alphabet = try!(unique_alphabet(&self.alphabet));
         if alphabet.len() < MINIMUM_ALPHABET_LENGTH {
             return Err(Error::AlphabetLength);
         }

--- a/src/harsh.rs
+++ b/src/harsh.rs
@@ -1,12 +1,11 @@
 use std::str;
 use {Error, Result};
-use {
-    DEFAULT_ALPHABET,
-    DEFAULT_SEPARATORS,
-    GUARD_DIV,
-    MINIMUM_ALPHABET_LENGTH,
-    SEPARATOR_DIV,
-};
+
+const DEFAULT_ALPHABET: &'static [u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+const DEFAULT_SEPARATORS: &'static [u8] = b"cfhistuCFHISTU";
+const SEPARATOR_DIV: f64 = 3.5;
+const GUARD_DIV: f64 = 12.0;
+const MINIMUM_ALPHABET_LENGTH: usize = 16;
 
 /// A rustic implementation of Hashids.
 /// 
@@ -570,7 +569,7 @@ mod tests {
 
     #[test]
     fn alphabet_and_separator_generation() {
-        use {DEFAULT_ALPHABET, DEFAULT_SEPARATORS};
+        use harsh::{DEFAULT_ALPHABET, DEFAULT_SEPARATORS};
 
         let (alphabet, separators) = harsh::alphabet_and_separators(&Some(DEFAULT_SEPARATORS.to_vec()), DEFAULT_ALPHABET, b"this is my salt");
 
@@ -580,7 +579,7 @@ mod tests {
 
     #[test]
     fn alphabet_and_separator_generation_with_few_separators() {
-        use {DEFAULT_ALPHABET};
+        use harsh::{DEFAULT_ALPHABET};
 
         let separators = b"fu";
         let (alphabet, separators) = harsh::alphabet_and_separators(&Some(separators.to_vec()), DEFAULT_ALPHABET, b"this is my salt");

--- a/src/harsh.rs
+++ b/src/harsh.rs
@@ -1,16 +1,18 @@
-use std::str;
-use {Error, Result};
 
-const DEFAULT_ALPHABET: &'static [u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+use {Error, Result};
+use std::str;
+
+const DEFAULT_ALPHABET: &'static [u8] =
+    b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
 const DEFAULT_SEPARATORS: &'static [u8] = b"cfhistuCFHISTU";
 const SEPARATOR_DIV: f64 = 3.5;
 const GUARD_DIV: f64 = 12.0;
 const MINIMUM_ALPHABET_LENGTH: usize = 16;
 
 /// A rustic implementation of Hashids.
-/// 
+///
 /// This should be created by use of the `HarshFactory` struct, which
-/// will be consumed upon initialization. `Harsh` is `Send + Sync`, 
+/// will be consumed upon initialization. `Harsh` is `Send + Sync`,
 /// meaning just one can be used pretty much through your system.
 #[derive(Clone, Debug)]
 pub struct Harsh {
@@ -61,12 +63,17 @@ impl Harsh {
         }
 
         if buffer.len() < self.hash_length {
-            let guard_index = (nhash as usize + buffer.bytes().nth(0).expect("hellfire and damnation") as usize) % self.guards.len();
+            let guard_index = (nhash as usize +
+                               buffer.bytes().nth(0).expect("hellfire and damnation") as usize) %
+                              self.guards.len();
             let guard = self.guards[guard_index];
             buffer.insert(0, guard as char);
 
             if buffer.len() < self.hash_length {
-                let guard_index = (nhash as usize + buffer.bytes().nth(2).expect("hellfire and damnation") as usize) % self.guards.len();
+                let guard_index =
+                    (nhash as usize +
+                     buffer.bytes().nth(2).expect("hellfire and damnation") as usize) %
+                    self.guards.len();
                 let guard = self.guards[guard_index];
                 buffer.push(guard as char);
             }
@@ -80,7 +87,10 @@ impl Harsh {
             }
 
             let (left, right) = alphabet.split_at(half_length);
-            buffer = format!("{}{}{}", String::from_utf8_lossy(right), buffer, String::from_utf8_lossy(left));
+            buffer = format!("{}{}{}",
+                             String::from_utf8_lossy(right),
+                             buffer,
+                             String::from_utf8_lossy(left));
 
             let excess = buffer.len() as i32 - self.hash_length as i32;
             if excess > 0 {
@@ -110,31 +120,37 @@ impl Harsh {
         }
 
         let mut alphabet = self.alphabet.clone();
-        
+
         let lottery = value[0];
         let value = &value[1..];
         let segments: Vec<_> = value.split(|u| self.separators.contains(u)).collect();
 
-        Some(segments.into_iter().map(|segment| {
-            let buffer = {
-                let mut buffer = Vec::with_capacity(self.salt.len() + alphabet.len() + 1);
-                buffer.push(lottery);
-                buffer.extend_from_slice(&self.salt);
-                buffer.extend_from_slice(&alphabet);
-                buffer
-            };
+        Some(segments.into_iter()
+            .map(|segment| {
+                let buffer = {
+                    let mut buffer = Vec::with_capacity(self.salt.len() + alphabet.len() + 1);
+                    buffer.push(lottery);
+                    buffer.extend_from_slice(&self.salt);
+                    buffer.extend_from_slice(&alphabet);
+                    buffer
+                };
 
-            let alphabet_len = alphabet.len();
-            shuffle(&mut alphabet, &buffer[..alphabet_len]);
-            unhash(segment, &alphabet)
-        }).collect())
+                let alphabet_len = alphabet.len();
+                shuffle(&mut alphabet, &buffer[..alphabet_len]);
+                unhash(segment, &alphabet)
+            })
+            .collect())
     }
 
     /// Encodes a hex string into a hashid.
     pub fn encode_hex(&self, hex: &str) -> Option<String> {
         let values: Option<Vec<_>> = hex.as_bytes()
             .chunks(12)
-            .map(|chunk| str::from_utf8(chunk).ok().and_then(|s| u64::from_str_radix(&("1".to_owned() + s), 16).ok()))
+            .map(|chunk| {
+                str::from_utf8(chunk)
+                    .ok()
+                    .and_then(|s| u64::from_str_radix(&("1".to_owned() + s), 16).ok())
+            })
             .collect();
 
         values.and_then(|values| self.encode(&values))
@@ -143,7 +159,7 @@ impl Harsh {
     /// Decodes a hashid into a hex string.
     pub fn decode_hex(&self, value: &str) -> Option<String> {
         use std::fmt::Write;
-        
+
         match self.decode(value) {
             None => None,
             Some(ref values) => {
@@ -192,8 +208,8 @@ impl HarshFactory {
 
     /// Provides a salt.
     ///
-    /// Note that this salt will be converted into a `[u8]` before use, meaning 
-    /// that multi-byte utf8 character values should be avoided. 
+    /// Note that this salt will be converted into a `[u8]` before use, meaning
+    /// that multi-byte utf8 character values should be avoided.
     pub fn salt<T: Into<Vec<u8>>>(mut self, salt: T) -> HarshFactory {
         self.salt = Some(salt.into());
         self
@@ -210,7 +226,7 @@ impl HarshFactory {
 
     /// Provides a set of separators.
     ///
-    /// Note that these separators will be converted into a `[u8]` before use, 
+    /// Note that these separators will be converted into a `[u8]` before use,
     /// meaning that multi-byte utf8 character values should be avoided.
     pub fn separators<T: Into<Vec<u8>>>(mut self, separators: T) -> HarshFactory {
         self.separators = Some(separators.into());
@@ -235,7 +251,8 @@ impl HarshFactory {
         }
 
         let salt = self.salt.unwrap_or_else(Vec::new);
-        let (mut alphabet, mut separators) = alphabet_and_separators(&self.separators, &alphabet, &salt);
+        let (mut alphabet, mut separators) =
+            alphabet_and_separators(&self.separators, &alphabet, &salt);
         let guards = guards(&mut alphabet, &mut separators);
 
         Ok(Harsh {
@@ -255,7 +272,7 @@ fn create_nhash(values: &[u64]) -> u64 {
 
 fn unique_alphabet(alphabet: &Option<Vec<u8>>) -> Result<Vec<u8>> {
     use std::collections::HashSet;
-    
+
     match *alphabet {
         None => {
             let mut vec = vec![0; DEFAULT_ALPHABET.len()];
@@ -287,14 +304,19 @@ fn unique_alphabet(alphabet: &Option<Vec<u8>>) -> Result<Vec<u8>> {
     }
 }
 
-fn alphabet_and_separators(separators: &Option<Vec<u8>>, alphabet: &[u8], salt: &[u8]) -> (Vec<u8>, Vec<u8>) {
+fn alphabet_and_separators(separators: &Option<Vec<u8>>,
+                           alphabet: &[u8],
+                           salt: &[u8])
+                           -> (Vec<u8>, Vec<u8>) {
     let separators = match *separators {
         None => DEFAULT_SEPARATORS,
         Some(ref separators) => separators,
     };
 
-    let mut separators: Vec<_> = separators.iter().cloned().filter(|item| alphabet.contains(item)).collect();
-    let mut alphabet: Vec<_> = alphabet.iter().cloned().filter(|item| !separators.contains(item)).collect();
+    let mut separators: Vec<_> =
+        separators.iter().cloned().filter(|item| alphabet.contains(item)).collect();
+    let mut alphabet: Vec<_> =
+        alphabet.iter().cloned().filter(|item| !separators.contains(item)).collect();
 
     shuffle(&mut separators, salt);
 
@@ -318,7 +340,7 @@ fn alphabet_and_separators(separators: &Option<Vec<u8>>, alphabet: &[u8], salt: 
 }
 
 fn guards(alphabet: &mut Vec<u8>, separators: &mut Vec<u8>) -> Vec<u8> {
-    let guard_count = (alphabet.len() as f64 / GUARD_DIV).ceil() as usize; 
+    let guard_count = (alphabet.len() as f64 / GUARD_DIV).ceil() as usize;
     if alphabet.len() < 3 {
         let guards = separators[..guard_count].to_vec();
         separators.drain(..guard_count);
@@ -326,7 +348,7 @@ fn guards(alphabet: &mut Vec<u8>, separators: &mut Vec<u8>) -> Vec<u8> {
     } else {
         let guards = alphabet[..guard_count].to_vec();
         alphabet.drain(..guard_count);
-        guards 
+        guards
     }
 }
 
@@ -341,7 +363,7 @@ fn shuffle(values: &mut [u8], salt: &[u8]) {
 
     for i in (1..values_length).map(|i| values_length - i) {
         v %= salt_length;
-        
+
         let n = salt[v] as usize;
         p += n;
         let j = (n + v + p) % i;
@@ -361,14 +383,15 @@ fn hash(mut value: u64, alphabet: &[u8]) -> String {
 
         if value == 0 {
             hash.reverse();
-            return String::from_utf8(hash).expect("omg fml")
+            return String::from_utf8(hash).expect("omg fml");
         }
     }
 }
 
 fn unhash(input: &[u8], alphabet: &[u8]) -> u64 {
     input.iter().enumerate().fold(0, |a, (idx, &value)| {
-        let pos = alphabet.iter().position(|&item| item == value).expect("what a world, what a world!");
+        let pos =
+            alphabet.iter().position(|&item| item == value).expect("what a world, what a world!");
         a + (pos as u64 * (alphabet.len() as u64).pow((input.len() - idx - 1) as u32))
     })
 }
@@ -389,8 +412,11 @@ mod tests {
             .init()
             .expect("failed to initialize harsh");
 
-        assert_eq!("4o6Z7KqxE", harsh.encode(&[1226198605112]).expect("failed to encode"), "error encoding [1226198605112]");
-        assert_eq!("laHquq", harsh.encode(&[1, 2, 3]).expect("failed to encode"));
+        assert_eq!("4o6Z7KqxE",
+                   harsh.encode(&[1226198605112]).expect("failed to encode"),
+                   "error encoding [1226198605112]");
+        assert_eq!("laHquq",
+                   harsh.encode(&[1, 2, 3]).expect("failed to encode"));
     }
 
     #[test]
@@ -401,7 +427,8 @@ mod tests {
             .init()
             .expect("failed to initialize harsh");
 
-        assert_eq!("GlaHquq0", harsh.encode(&[1, 2, 3]).expect("failed to encode"));
+        assert_eq!("GlaHquq0",
+                   harsh.encode(&[1, 2, 3]).expect("failed to encode"));
     }
 
     #[test]
@@ -412,7 +439,8 @@ mod tests {
             .init()
             .expect("failed to initialize harsh");
 
-        assert_eq!("9LGlaHquq06D", harsh.encode(&[1, 2, 3]).expect("failed to encode"));
+        assert_eq!("9LGlaHquq06D",
+                   harsh.encode(&[1, 2, 3]).expect("failed to encode"));
     }
 
     #[test]
@@ -422,8 +450,11 @@ mod tests {
             .init()
             .expect("failed to initialize harsh");
 
-        assert_eq!(&[1226198605112], &harsh.decode("4o6Z7KqxE").expect("failed to decode")[..], "error decoding \"4o6Z7KqxE\"");
-        assert_eq!(&[1u64, 2, 3], &harsh.decode("laHquq").expect("failed to decode")[..]);
+        assert_eq!(&[1226198605112],
+                   &harsh.decode("4o6Z7KqxE").expect("failed to decode")[..],
+                   "error decoding \"4o6Z7KqxE\"");
+        assert_eq!(&[1u64, 2, 3],
+                   &harsh.decode("laHquq").expect("failed to decode")[..]);
     }
 
     #[test]
@@ -434,7 +465,8 @@ mod tests {
             .init()
             .expect("failed to initialize harsh");
 
-        assert_eq!(&[1u64, 2, 3], &harsh.decode("GlaHquq0").expect("failed to decode")[..]);
+        assert_eq!(&[1u64, 2, 3],
+                   &harsh.decode("GlaHquq0").expect("failed to decode")[..]);
     }
 
     #[test]
@@ -445,7 +477,8 @@ mod tests {
             .init()
             .expect("failed to initialize harsh");
 
-        assert_eq!(&[1u64, 2, 3], &harsh.decode("9LGlaHquq06D").expect("failed to decode")[..]);
+        assert_eq!(&[1u64, 2, 3],
+                   &harsh.decode("9LGlaHquq06D").expect("failed to decode")[..]);
     }
 
     #[test]
@@ -455,18 +488,38 @@ mod tests {
             .init()
             .expect("failed to initialize harsh");
 
-        assert_eq!("lzY", &harsh.encode_hex("FA").expect("failed to encode"), "error encoding `FA`");
-        assert_eq!("MemE", &harsh.encode_hex("26dd").expect("failed to encode"), "error encoding `26dd`");
-        assert_eq!("eBMrb", &harsh.encode_hex("FF1A").expect("failed to encode"), "error encoding `FF1A`");
-        assert_eq!("D9NPE", &harsh.encode_hex("12abC").expect("failed to encode"), "error encoding `12abC`");
-        assert_eq!("9OyNW", &harsh.encode_hex("185b0").expect("failed to encode"), "error encoding `185b0`");
-        assert_eq!("MRWNE", &harsh.encode_hex("17b8d").expect("failed to encode"), "error encoding `17b8d`");
-        assert_eq!("4o6Z7KqxE", &harsh.encode_hex("1d7f21dd38").expect("failed to encode"), "error encoding `1d7f21dd38`");
-        assert_eq!("ooweQVNB", &harsh.encode_hex("20015111d").expect("failed to encode"), "error encoding `20015111d`");
-        assert_eq!("kRNrpKlJ", &harsh.encode_hex("deadbeef").expect("failed to encode"), "error encoding `deadbeef`");
+        assert_eq!("lzY",
+                   &harsh.encode_hex("FA").expect("failed to encode"),
+                   "error encoding `FA`");
+        assert_eq!("MemE",
+                   &harsh.encode_hex("26dd").expect("failed to encode"),
+                   "error encoding `26dd`");
+        assert_eq!("eBMrb",
+                   &harsh.encode_hex("FF1A").expect("failed to encode"),
+                   "error encoding `FF1A`");
+        assert_eq!("D9NPE",
+                   &harsh.encode_hex("12abC").expect("failed to encode"),
+                   "error encoding `12abC`");
+        assert_eq!("9OyNW",
+                   &harsh.encode_hex("185b0").expect("failed to encode"),
+                   "error encoding `185b0`");
+        assert_eq!("MRWNE",
+                   &harsh.encode_hex("17b8d").expect("failed to encode"),
+                   "error encoding `17b8d`");
+        assert_eq!("4o6Z7KqxE",
+                   &harsh.encode_hex("1d7f21dd38").expect("failed to encode"),
+                   "error encoding `1d7f21dd38`");
+        assert_eq!("ooweQVNB",
+                   &harsh.encode_hex("20015111d").expect("failed to encode"),
+                   "error encoding `20015111d`");
+        assert_eq!("kRNrpKlJ",
+                   &harsh.encode_hex("deadbeef").expect("failed to encode"),
+                   "error encoding `deadbeef`");
 
         let harsh = HarshFactory::new().init().unwrap();
-        assert_eq!("y42LW46J9luq3Xq9XMly", &harsh.encode_hex("507f1f77bcf86cd799439011").expect("failed to encode"), "error encoding `507f1f77bcf86cd799439011`");
+        assert_eq!("y42LW46J9luq3Xq9XMly",
+                   &harsh.encode_hex("507f1f77bcf86cd799439011").expect("failed to encode"),
+                   "error encoding `507f1f77bcf86cd799439011`");
     }
 
     #[test]
@@ -476,8 +529,9 @@ mod tests {
             .length(10)
             .init()
             .expect("failed to initialize harsh");
-            
-        assert_eq!("GkRNrpKlJd", &harsh.encode_hex("deadbeef").expect("failed to encode"));
+
+        assert_eq!("GkRNrpKlJd",
+                   &harsh.encode_hex("deadbeef").expect("failed to encode"));
     }
 
     #[test]
@@ -487,8 +541,9 @@ mod tests {
             .length(12)
             .init()
             .expect("failed to initialize harsh");
-            
-        assert_eq!("RGkRNrpKlJde", &harsh.encode_hex("deadbeef").expect("failed to encode"));
+
+        assert_eq!("RGkRNrpKlJde",
+                   &harsh.encode_hex("deadbeef").expect("failed to encode"));
     }
 
     #[test]
@@ -498,18 +553,38 @@ mod tests {
             .init()
             .expect("failed to initialize harsh");
 
-        assert_eq!("fa", harsh.decode_hex("lzY").expect("failed to decode"), "error decoding `FA`");
-        assert_eq!("26dd", harsh.decode_hex("MemE").expect("failed to decode"), "error decoding `26dd`");
-        assert_eq!("ff1a", harsh.decode_hex("eBMrb").expect("failed to decode"), "error decoding `FF1A`");
-        assert_eq!("12abc", harsh.decode_hex("D9NPE").expect("failed to decode"), "error decoding `12abC`");
-        assert_eq!("185b0", harsh.decode_hex("9OyNW").expect("failed to decode"), "error decoding `185b0`");
-        assert_eq!("17b8d", harsh.decode_hex("MRWNE").expect("failed to decode"), "error decoding `17b8d`");
-        assert_eq!("1d7f21dd38", harsh.decode_hex("4o6Z7KqxE").expect("failed to decode"), "error decoding `1d7f21dd38`");
-        assert_eq!("20015111d", harsh.decode_hex("ooweQVNB").expect("failed to decode"), "error decoding `20015111d`");
-        assert_eq!("deadbeef", harsh.decode_hex("kRNrpKlJ").expect("failed to decode"), "error decoding `deadbeef`");
+        assert_eq!("fa",
+                   harsh.decode_hex("lzY").expect("failed to decode"),
+                   "error decoding `FA`");
+        assert_eq!("26dd",
+                   harsh.decode_hex("MemE").expect("failed to decode"),
+                   "error decoding `26dd`");
+        assert_eq!("ff1a",
+                   harsh.decode_hex("eBMrb").expect("failed to decode"),
+                   "error decoding `FF1A`");
+        assert_eq!("12abc",
+                   harsh.decode_hex("D9NPE").expect("failed to decode"),
+                   "error decoding `12abC`");
+        assert_eq!("185b0",
+                   harsh.decode_hex("9OyNW").expect("failed to decode"),
+                   "error decoding `185b0`");
+        assert_eq!("17b8d",
+                   harsh.decode_hex("MRWNE").expect("failed to decode"),
+                   "error decoding `17b8d`");
+        assert_eq!("1d7f21dd38",
+                   harsh.decode_hex("4o6Z7KqxE").expect("failed to decode"),
+                   "error decoding `1d7f21dd38`");
+        assert_eq!("20015111d",
+                   harsh.decode_hex("ooweQVNB").expect("failed to decode"),
+                   "error decoding `20015111d`");
+        assert_eq!("deadbeef",
+                   harsh.decode_hex("kRNrpKlJ").expect("failed to decode"),
+                   "error decoding `deadbeef`");
 
-        let harsh = HarshFactory::new().init().unwrap();        
-        assert_eq!("507f1f77bcf86cd799439011", harsh.decode_hex("y42LW46J9luq3Xq9XMly").expect("failed to decode"), "error decoding `y42LW46J9luq3Xq9XMly`");
+        let harsh = HarshFactory::new().init().unwrap();
+        assert_eq!("507f1f77bcf86cd799439011",
+                   harsh.decode_hex("y42LW46J9luq3Xq9XMly").expect("failed to decode"),
+                   "error decoding `y42LW46J9luq3Xq9XMly`");
     }
 
     #[test]
@@ -519,8 +594,10 @@ mod tests {
             .length(10)
             .init()
             .expect("failed to initialize harsh");
-            
-        assert_eq!("deadbeef", harsh.decode_hex("GkRNrpKlJd").expect("failed to decode"), "failed to decode GkRNrpKlJd");
+
+        assert_eq!("deadbeef",
+                   harsh.decode_hex("GkRNrpKlJd").expect("failed to decode"),
+                   "failed to decode GkRNrpKlJd");
     }
 
     #[test]
@@ -530,8 +607,10 @@ mod tests {
             .length(12)
             .init()
             .expect("failed to initialize harsh");
-            
-        assert_eq!("deadbeef", harsh.decode_hex("RGkRNrpKlJde").expect("failed to decode"), "failed to decode RGkRNrpKlJde");
+
+        assert_eq!("deadbeef",
+                   harsh.decode_hex("RGkRNrpKlJde").expect("failed to decode"),
+                   "failed to decode RGkRNrpKlJde");
     }
 
     #[test]
@@ -541,7 +620,9 @@ mod tests {
             .init()
             .expect("failed to initialize harsh");
 
-        assert_eq!("mdfphx", harsh.encode(&[1, 2, 3]).expect("failed to encode"), "failed to encode [1, 2, 3]");
+        assert_eq!("mdfphx",
+                   harsh.encode(&[1, 2, 3]).expect("failed to encode"),
+                   "failed to encode [1, 2, 3]");
     }
 
     #[test]
@@ -551,8 +632,10 @@ mod tests {
             .init()
             .expect("failed to initialize harsh");
 
-        assert_eq!(&[1, 2, 3], &harsh.decode("mdfphx").expect("failed to decode")[..], "failed to decode mdfphx");
-    }   
+        assert_eq!(&[1, 2, 3],
+                   &harsh.decode("mdfphx").expect("failed to decode")[..],
+                   "failed to decode mdfphx");
+    }
 
     #[test]
     fn create_nhash() {
@@ -571,21 +654,30 @@ mod tests {
     fn alphabet_and_separator_generation() {
         use harsh::{DEFAULT_ALPHABET, DEFAULT_SEPARATORS};
 
-        let (alphabet, separators) = harsh::alphabet_and_separators(&Some(DEFAULT_SEPARATORS.to_vec()), DEFAULT_ALPHABET, b"this is my salt");
+        let (alphabet, separators) =
+            harsh::alphabet_and_separators(&Some(DEFAULT_SEPARATORS.to_vec()),
+                                           DEFAULT_ALPHABET,
+                                           b"this is my salt");
 
-        assert_eq!("AdG05N6y2rljDQak4xgzn8ZR1oKYLmJpEbVq3OBv9WwXPMe7", alphabet.iter().map(|&u| u as char).collect::<String>());
-        assert_eq!("UHuhtcITCsFifS", separators.iter().map(|&u| u as char).collect::<String>());
+        assert_eq!("AdG05N6y2rljDQak4xgzn8ZR1oKYLmJpEbVq3OBv9WwXPMe7",
+                   alphabet.iter().map(|&u| u as char).collect::<String>());
+        assert_eq!("UHuhtcITCsFifS",
+                   separators.iter().map(|&u| u as char).collect::<String>());
     }
 
     #[test]
     fn alphabet_and_separator_generation_with_few_separators() {
-        use harsh::{DEFAULT_ALPHABET};
+        use harsh::DEFAULT_ALPHABET;
 
         let separators = b"fu";
-        let (alphabet, separators) = harsh::alphabet_and_separators(&Some(separators.to_vec()), DEFAULT_ALPHABET, b"this is my salt");
+        let (alphabet, separators) = harsh::alphabet_and_separators(&Some(separators.to_vec()),
+                                                                    DEFAULT_ALPHABET,
+                                                                    b"this is my salt");
 
-        assert_eq!("4RVQrYM87wKPNSyTBGU1E6FIC9ALtH0ZD2Wxz3vs5OXJ", alphabet.iter().map(|&u| u as char).collect::<String>());
-        assert_eq!("ufabcdeghijklmnopq", separators.iter().map(|&u| u as char).collect::<String>());        
+        assert_eq!("4RVQrYM87wKPNSyTBGU1E6FIC9ALtH0ZD2Wxz3vs5OXJ",
+                   alphabet.iter().map(|&u| u as char).collect::<String>());
+        assert_eq!("ufabcdeghijklmnopq",
+                   separators.iter().map(|&u| u as char).collect::<String>());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(question_mark, type_ascription)]
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
-#[cfg(test)] mod tests;
+#[cfg(test)]
+mod tests;
 
 mod error;
 mod harsh;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,3 @@ mod harsh;
 
 pub use error::{Error, Result};
 pub use harsh::{Harsh, HarshFactory};
-
-const DEFAULT_ALPHABET: &'static [u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
-const DEFAULT_SEPARATORS: &'static [u8] = b"cfhistuCFHISTU";
-const SEPARATOR_DIV: f64 = 3.5;
-const GUARD_DIV: f64 = 12.0;
-const MINIMUM_ALPHABET_LENGTH: usize = 16;

--- a/src/tests/bad_input.rs
+++ b/src/tests/bad_input.rs
@@ -2,41 +2,47 @@ use harsh::{Harsh, HarshFactory};
 
 #[test]
 fn small_alphabet() {
-    assert!(
-        !HarshFactory::new().alphabet("1234567890").init().is_ok(),
-        "should throw an error with a small alphabet"
-    );
+    assert!(!HarshFactory::new().alphabet("1234567890").init().is_ok(),
+            "should throw an error with a small alphabet");
 }
 
 #[test]
 fn spaces_in_alphabet() {
-    assert!(
-        !HarshFactory::new().alphabet("a cdefghijklmnopqrstuvwxyz").init().is_ok(),
-        "should throw an error when alphabet includes spaces"
-    );
+    assert!(!HarshFactory::new().alphabet("a cdefghijklmnopqrstuvwxyz").init().is_ok(),
+            "should throw an error when alphabet includes spaces");
 }
 
 #[test]
 fn should_return_none_for_encoding_nothing() {
-    assert_eq!(None, Harsh::default().encode(&[]), "should return None when encoding an empty array");
+    assert_eq!(None,
+               Harsh::default().encode(&[]),
+               "should return None when encoding an empty array");
 }
 
 #[test]
 fn should_return_none_for_decoding_nothing() {
-    assert_eq!(None, Harsh::default().decode(""), "should return None when decoding nothing");
+    assert_eq!(None,
+               Harsh::default().decode(""),
+               "should return None when decoding nothing");
 }
 
 #[test]
 fn should_return_none_for_decoding_invalid_id() {
-    assert_eq!(None, Harsh::default().decode("f"), "should return None when decoding an invalid id");
+    assert_eq!(None,
+               Harsh::default().decode("f"),
+               "should return None when decoding an invalid id");
 }
 
 #[test]
 fn should_return_none_when_encoding_non_hex_input() {
-    assert_eq!(None, Harsh::default().encode_hex("z"), "should return None when hex-encoding non-hex input");
+    assert_eq!(None,
+               Harsh::default().encode_hex("z"),
+               "should return None when hex-encoding non-hex input");
 }
 
 #[test]
 fn should_return_none_when_hex_decoding_invalid_id() {
-    assert_eq!(None, Harsh::default().decode_hex("f"), "should return None when hex-decoding an invalid id");
+    assert_eq!(None,
+               Harsh::default().decode_hex("f"),
+               "should return None when hex-decoding an invalid id");
 }

--- a/src/tests/custom_alphabet.rs
+++ b/src/tests/custom_alphabet.rs
@@ -9,27 +9,32 @@ fn bad_alphabet() {
 
 #[test]
 fn separators_alphabet() {
-    test_alphabet("abdegjklCFHISTUc", "should work with half the alphabet being separators");
+    test_alphabet("abdegjklCFHISTUc",
+                  "should work with half the alphabet being separators");
 }
 
 #[test]
 fn two_separators() {
-    test_alphabet("abdegjklmnopqrSF", "should work with exactly two separators");
+    test_alphabet("abdegjklmnopqrSF",
+                  "should work with exactly two separators");
 }
 
 #[test]
 fn no_separators() {
-    test_alphabet("abdegjklmnopqrvwxyzABDEGJKLMNOPQRVWXYZ1234567890", "should work with no separators");
+    test_alphabet("abdegjklmnopqrvwxyzABDEGJKLMNOPQRVWXYZ1234567890",
+                  "should work with no separators");
 }
 
 #[test]
 fn long_alphabet() {
-    test_alphabet("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890`~!@#$%^&*()-_=+\\|'\";:/?.>,<{[}]", "should work with super-long alphabet");
+    test_alphabet("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890`~!@#$%^&*()-_=+\\|'\";:/?.>,<{[}]",
+                  "should work with super-long alphabet");
 }
 
 #[test]
 fn weird_alphabet() {
-    test_alphabet("`~!@#$%^&*()-_=+\\|'\";:/?.>,<{[}]", "should work with a weird alphabet");
+    test_alphabet("`~!@#$%^&*()-_=+\\|'\";:/?.>,<{[}]",
+                  "should work with a weird alphabet");
 }
 
 fn test_alphabet(alphabet: &str, message: &str) {

--- a/src/tests/custom_params.rs
+++ b/src/tests/custom_params.rs
@@ -1,28 +1,35 @@
 use harsh::HarshFactory;
 
-const TEST_CASES: [(&'static str, &'static [u64]); 14] = [
-	("nej1m3d5a6yn875e7gr9kbwpqol02q", &[0]),
-	("dw1nqdp92yrajvl9v6k3gl5mb0o8ea", &[1]),
-	("onqr0bk58p642wldq14djmw21ygl39", &[928728]),
-	("18apy3wlqkjvd5h1id7mn5ore2d06b", &[1, 2, 3]),
-	("o60edky1ng3vl9hbfavwr5pa2q8mb9", &[1, 0, 0]),
-	("o60edky1ng3vlqfbfp4wr5pa2q8mb9", &[0, 0, 1]),
-	("qek2a08gpl575efrfd7yomj9dwbr63", &[0, 0, 0]),
-	("m3d5a6yn875rae8y81a94gr9kbwpqo", &[1000000000000]),
-	("1q3y98ln48w96kpo0wgk314w5mak2d", &[9007199254740991]),
-	("op7qrcdc3cgc2c0cbcrcoc5clce4d6", &[5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5]),
-	("5430bd2jo0lxyfkfjfyojej5adqdy4", &[10000000000, 0, 0, 0, 999999999999999]),
-	("aa5kow86ano1pt3e1aqm239awkt9pk380w9l3q6", &[9007199254740991, 9007199254740991, 9007199254740991]),
-	("mmmykr5nuaabgwnohmml6dakt00jmo3ainnpy2mk", &[1000000001, 1000000002, 1000000003, 1000000004, 1000000005]),
-	("w1hwinuwt1cbs6xwzafmhdinuotpcosrxaz0fahl", &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
-];
+const TEST_CASES: [(&'static str, &'static [u64]); 14] =
+    [("nej1m3d5a6yn875e7gr9kbwpqol02q", &[0]),
+     ("dw1nqdp92yrajvl9v6k3gl5mb0o8ea", &[1]),
+     ("onqr0bk58p642wldq14djmw21ygl39", &[928728]),
+     ("18apy3wlqkjvd5h1id7mn5ore2d06b", &[1, 2, 3]),
+     ("o60edky1ng3vl9hbfavwr5pa2q8mb9", &[1, 0, 0]),
+     ("o60edky1ng3vlqfbfp4wr5pa2q8mb9", &[0, 0, 1]),
+     ("qek2a08gpl575efrfd7yomj9dwbr63", &[0, 0, 0]),
+     ("m3d5a6yn875rae8y81a94gr9kbwpqo", &[1000000000000]),
+     ("1q3y98ln48w96kpo0wgk314w5mak2d", &[9007199254740991]),
+     ("op7qrcdc3cgc2c0cbcrcoc5clce4d6", &[5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5]),
+     ("5430bd2jo0lxyfkfjfyojej5adqdy4", &[10000000000, 0, 0, 0, 999999999999999]),
+     ("aa5kow86ano1pt3e1aqm239awkt9pk380w9l3q6",
+      &[9007199254740991, 9007199254740991, 9007199254740991]),
+     ("mmmykr5nuaabgwnohmml6dakt00jmo3ainnpy2mk",
+      &[1000000001, 1000000002, 1000000003, 1000000004, 1000000005]),
+     ("w1hwinuwt1cbs6xwzafmhdinuotpcosrxaz0fahl",
+      &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])];
 
 #[test]
 fn custom_params() {
-    let harsh = HarshFactory::new().salt("this is my salt").length(30).alphabet("xzal86grmb4jhysfoqp3we7291kuct5iv0nd").init().unwrap();
+    let harsh = HarshFactory::new()
+        .salt("this is my salt")
+        .length(30)
+        .alphabet("xzal86grmb4jhysfoqp3we7291kuct5iv0nd")
+        .init()
+        .unwrap();
 
     for &(hash, values) in &TEST_CASES {
-		assert_eq!(hash, harsh.encode(values).unwrap());
-		assert_eq!(values, &harsh.decode(hash).unwrap()[..]);
+        assert_eq!(hash, harsh.encode(values).unwrap());
+        assert_eq!(values, &harsh.decode(hash).unwrap()[..]);
     }
 }

--- a/src/tests/custom_params_hex.rs
+++ b/src/tests/custom_params_hex.rs
@@ -1,22 +1,34 @@
 use harsh::HarshFactory;
 
-const TEST_CASES: [(&'static str, &'static str); 8] = [
-	("0dbq3jwa8p4b3gk6gb8bv21goerm96", "deadbeef"),
-	("190obdnk4j02pajjdande7aqj628mr", "abcdef123456"),
-	("a1nvl5d9m3yo8pj1fqag8p9pqw4dyl", "ABCDDD6666DDEEEEEEEEE"),
-	("1nvlml93k3066oas3l9lr1wn1k67dy", "507f1f77bcf86cd799439011"),
-	("mgyband33ye3c6jj16yq1jayh6krqjbo", "f00000fddddddeeeee4444444ababab"),
-	("9mnwgllqg1q2tdo63yya35a9ukgl6bbn6qn8", "abcdef123456abcdef123456abcdef123456"),
-	("edjrkn9m6o69s0ewnq5lqanqsmk6loayorlohwd963r53e63xmml29", "f000000000000000000000000000000000000000000000000000f"),
-	("grekpy53r2pjxwyjkl9aw0k3t5la1b8d5r1ex9bgeqmy93eata0eq0", "fffffffffffffffffffffffffffffffffffffffffffffffffffff"),
-];
+const TEST_CASES: [(&'static str, &'static str); 8] =
+    [("0dbq3jwa8p4b3gk6gb8bv21goerm96", "deadbeef"),
+     ("190obdnk4j02pajjdande7aqj628mr", "abcdef123456"),
+     ("a1nvl5d9m3yo8pj1fqag8p9pqw4dyl", "ABCDDD6666DDEEEEEEEEE"),
+     ("1nvlml93k3066oas3l9lr1wn1k67dy", "507f1f77bcf86cd799439011"),
+     ("mgyband33ye3c6jj16yq1jayh6krqjbo", "f00000fddddddeeeee4444444ababab"),
+     ("9mnwgllqg1q2tdo63yya35a9ukgl6bbn6qn8", "abcdef123456abcdef123456abcdef123456"),
+     ("edjrkn9m6o69s0ewnq5lqanqsmk6loayorlohwd963r53e63xmml29",
+      "f000000000000000000000000000000000000000000000000000f"),
+     ("grekpy53r2pjxwyjkl9aw0k3t5la1b8d5r1ex9bgeqmy93eata0eq0",
+      "fffffffffffffffffffffffffffffffffffffffffffffffffffff")];
 
 #[test]
 fn custom_params_hex() {
-    let harsh = HarshFactory::new().salt("this is my salt").length(30).alphabet("xzal86grmb4jhysfoqp3we7291kuct5iv0nd").init().unwrap();
+    let harsh = HarshFactory::new()
+        .salt("this is my salt")
+        .length(30)
+        .alphabet("xzal86grmb4jhysfoqp3we7291kuct5iv0nd")
+        .init()
+        .unwrap();
 
     for &(hash, value) in &TEST_CASES {
-		assert_eq!(hash, harsh.encode_hex(value).unwrap(), "failed to encode \"{}\"", value);
-		assert_eq!(value.to_lowercase(), harsh.decode_hex(hash).unwrap(), "failed to decode \"{}\"", hash);
+        assert_eq!(hash,
+                   harsh.encode_hex(value).unwrap(),
+                   "failed to encode \"{}\"",
+                   value);
+        assert_eq!(value.to_lowercase(),
+                   harsh.decode_hex(hash).unwrap(),
+                   "failed to decode \"{}\"",
+                   hash);
     }
 }

--- a/src/tests/custom_salt.rs
+++ b/src/tests/custom_salt.rs
@@ -17,14 +17,16 @@ fn ordinary_salt() {
 
 #[test]
 fn long_salt() {
-    test_salt("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890`~!@#$%^&*()-_=+\\|'\";:/?.>,<{[}]", "should work with a really long salt");
+    test_salt("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890`~!@#$%^&*()-_=+\\|'\";:/?.>,<{[}]",
+              "should work with a really long salt");
 }
 
 #[test]
 fn weird_salt() {
-    test_salt("`~!@#$%^&*()-_=+\\|'\";:/?.>,<{[}]", "should work with a weird salt")
+    test_salt("`~!@#$%^&*()-_=+\\|'\";:/?.>,<{[}]",
+              "should work with a weird salt")
 }
 
 fn test_salt(salt: &str, message: &str) {
-    assert!(HarshFactory::new().salt(salt).init().is_ok(), "{}", message); 
+    assert!(HarshFactory::new().salt(salt).init().is_ok(), "{}", message);
 }

--- a/src/tests/default_params.rs
+++ b/src/tests/default_params.rs
@@ -1,28 +1,30 @@
 use harsh::Harsh;
 
-const TEST_CASES: [(&'static str, &'static [u64]); 14] = [
-    ("gY", &[0]),
-    ("jR", &[1]),
-    ("R8ZN0", &[928728]),
-    ("o2fXhV", &[1, 2, 3]),
-    ("jRfMcP", &[1, 0, 0]),
-    ("jQcMcW", &[0, 0, 1]),
-    ("gYcxcr", &[0, 0, 0]),
-    ("gLpmopgO6", &[1000000000000]),
-    ("lEW77X7g527", &[9007199254740991]),
-    ("BrtltWt2tyt1tvt7tJt2t1tD", &[5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5]),
-    ("G6XOnGQgIpcVcXcqZ4B8Q8B9y", &[10000000000, 0, 0, 0, 999999999999999]),
-    ("5KoLLVL49RLhYkppOplM6piwWNNANny8N", &[9007199254740991, 9007199254740991, 9007199254740991]),
-    ("BPg3Qx5f8VrvQkS16wpmwIgj9Q4Jsr93gqx", &[1000000001, 1000000002, 1000000003, 1000000004, 1000000005]),
-    ("1wfphpilsMtNumCRFRHXIDSqT2UPcWf1hZi3s7tN", &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
-];
+const TEST_CASES: [(&'static str, &'static [u64]); 14] =
+    [("gY", &[0]),
+     ("jR", &[1]),
+     ("R8ZN0", &[928728]),
+     ("o2fXhV", &[1, 2, 3]),
+     ("jRfMcP", &[1, 0, 0]),
+     ("jQcMcW", &[0, 0, 1]),
+     ("gYcxcr", &[0, 0, 0]),
+     ("gLpmopgO6", &[1000000000000]),
+     ("lEW77X7g527", &[9007199254740991]),
+     ("BrtltWt2tyt1tvt7tJt2t1tD", &[5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5]),
+     ("G6XOnGQgIpcVcXcqZ4B8Q8B9y", &[10000000000, 0, 0, 0, 999999999999999]),
+     ("5KoLLVL49RLhYkppOplM6piwWNNANny8N",
+      &[9007199254740991, 9007199254740991, 9007199254740991]),
+     ("BPg3Qx5f8VrvQkS16wpmwIgj9Q4Jsr93gqx",
+      &[1000000001, 1000000002, 1000000003, 1000000004, 1000000005]),
+     ("1wfphpilsMtNumCRFRHXIDSqT2UPcWf1hZi3s7tN",
+      &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])];
 
 #[test]
 fn default_params() {
     let harsh = Harsh::default();
 
     for &(hash, values) in &TEST_CASES {
-		assert_eq!(hash, harsh.encode(values).unwrap());
-		assert_eq!(values, &harsh.decode(hash).unwrap()[..]);
+        assert_eq!(hash, harsh.encode(values).unwrap());
+        assert_eq!(values, &harsh.decode(hash).unwrap()[..]);
     }
 }

--- a/src/tests/default_params_hex.rs
+++ b/src/tests/default_params_hex.rs
@@ -1,22 +1,29 @@
 use harsh::Harsh;
 
-const TEST_CASES: [(&'static str, &'static str); 8] = [
-	("wpVL4j9g", "deadbeef"),
-	("kmP69lB3xv", "abcdef123456"),
-	("47JWg0kv4VU0G2KBO2", "ABCDDD6666DDEEEEEEEEE"),
-	("y42LW46J9luq3Xq9XMly", "507f1f77bcf86cd799439011"),
-	("m1rO8xBQNquXmLvmO65BUO9KQmj", "f00000fddddddeeeee4444444ababab"),
-	("wBlnMA23NLIQDgw7XxErc2mlNyAjpw", "abcdef123456abcdef123456abcdef123456"),
-	("VwLAoD9BqlT7xn4ZnBXJFmGZ51ZqrBhqrymEyvYLIP199", "f000000000000000000000000000000000000000000000000000f"),
-	("nBrz1rYyV0C0XKNXxB54fWN0yNvVjlip7127Jo3ri0Pqw", "fffffffffffffffffffffffffffffffffffffffffffffffffffff"),
-];
+const TEST_CASES: [(&'static str, &'static str); 8] =
+    [("wpVL4j9g", "deadbeef"),
+     ("kmP69lB3xv", "abcdef123456"),
+     ("47JWg0kv4VU0G2KBO2", "ABCDDD6666DDEEEEEEEEE"),
+     ("y42LW46J9luq3Xq9XMly", "507f1f77bcf86cd799439011"),
+     ("m1rO8xBQNquXmLvmO65BUO9KQmj", "f00000fddddddeeeee4444444ababab"),
+     ("wBlnMA23NLIQDgw7XxErc2mlNyAjpw", "abcdef123456abcdef123456abcdef123456"),
+     ("VwLAoD9BqlT7xn4ZnBXJFmGZ51ZqrBhqrymEyvYLIP199",
+      "f000000000000000000000000000000000000000000000000000f"),
+     ("nBrz1rYyV0C0XKNXxB54fWN0yNvVjlip7127Jo3ri0Pqw",
+      "fffffffffffffffffffffffffffffffffffffffffffffffffffff")];
 
 #[test]
 fn default_params_hex() {
     let harsh = Harsh::default();
-    
+
     for &(hash, value) in &TEST_CASES {
-		assert_eq!(hash, harsh.encode_hex(value).unwrap(), "failed to encode \"{}\"", value);
-		assert_eq!(value.to_lowercase(), harsh.decode_hex(hash).unwrap(), "failed to decode \"{}\"", hash);
+        assert_eq!(hash,
+                   harsh.encode_hex(value).unwrap(),
+                   "failed to encode \"{}\"",
+                   value);
+        assert_eq!(value.to_lowercase(),
+                   harsh.decode_hex(hash).unwrap(),
+                   "failed to decode \"{}\"",
+                   hash);
     }
 }

--- a/src/tests/min_length.rs
+++ b/src/tests/min_length.rs
@@ -33,6 +33,9 @@ fn test_minimum_length(n: usize) {
     let hash = harsh.encode(NUMBERS).expect("failed to encode values");
     let values = harsh.decode(&hash).expect("failed to decode hash");
 
-    assert_eq!(NUMBERS, &values[..], "encoding/decoding failed at length {}", n);
+    assert_eq!(NUMBERS,
+               &values[..],
+               "encoding/decoding failed at length {}",
+               n);
     assert!(hash.len() >= n, "length too short for {}", n);
 }


### PR DESCRIPTION
Removed type ascription and the question mark operator. Also ran `cargo fmt`  (with a config file) and bumped the version to 0.1.1.