### PR TITLE
Do not depend on clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harsh"
-version = "0.1.2"
+version = "0.1.3"
 description = "Hashids implementation for Rust"
 readme = "README.md"
 repository = "https://github.com/archer884/harsh"
@@ -9,7 +9,3 @@ authors = ["J/A <archer884@gmail.com>"]
 exclude = [".travis.yml"]
 
 [dependencies]
-clippy = {version = "0.0.95", optional = true}
-
-[features]
-default = []

--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Maybe one of these days I'll get around to fixing my website up. :)
 Changelog
 ---------
 
+### 0.1.3
+
+- Remove dependency on clippy. (Still using clippy, but just as `cargo clippy` now.)
+
 ### 0.1.2
 
 - Changed `HarshFactory` to `HarshBuilder` in order to stop rubbing my OCD the wrong way<sup>1</sup>

--- a/src/harsh.rs
+++ b/src/harsh.rs
@@ -26,7 +26,7 @@ pub struct Harsh {
 impl Harsh {
     /// Encodes a slice of `u64` values into a single hashid.
     pub fn encode(&self, values: &[u64]) -> Option<String> {
-        if values.len() == 0 {
+        if values.is_empty() {
             return None;
         }
 
@@ -353,7 +353,7 @@ fn guards(alphabet: &mut Vec<u8>, separators: &mut Vec<u8>) -> Vec<u8> {
 }
 
 fn shuffle(values: &mut [u8], salt: &[u8]) {
-    if salt.len() == 0 {
+    if salt.is_empty() {
         return;
     }
 


### PR DESCRIPTION
It's not that I don't like clippy, it's just that updating it as a dependency is a train wreck, and it's a lot easier to just use the cargo tool.