### PR TITLE
Add continuous integration with AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 
 [![hashids](http://hashids.org/public/img/hashids.gif "Hashids")](http://hashids.org/)
 
-[![Build Status][travis-image]][travis-url]
+[![Travis CI build Status][travis-image]][travis-url]
+[![AppVeyor build Status][appveyor-image]][appveyor-url]
 
 **Harsh** is a Rust implementation of the **Hashids** JavaScript library to generate YouTube-like ids from numbers. Use it when you don't want to expose your database ids to the user: [http://hashids.org/javascript](http://hashids.org/javascript)
 
@@ -157,6 +158,9 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 
 [travis-url]: https://travis-ci.org/archer884/harsh
 [travis-image]: https://travis-ci.org/archer884/harsh.svg?branch=master
+
+[appveyor-url]: (https://ci.appveyor.com/project/archer884/harsh)
+[appveyor-image]: https://ci.appveyor.com/api/projects/status/github/archer884/harsh?branch=master&svg=true
 
 [license-url-mit]: https://github.com/archer884/harsh/blob/master/LICENSE-MIT
 [license-url-ap2]: https://github.com/archer884/harsh/blob/master/LICENSE-APACHE

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,43 @@
+image: Visual Studio 2017
+
+environment:
+  host: x86_64-pc-windows-msvc        # Triple of host platform
+  matrix:
+    - platform: x86_64                # Name (is not used other than naming things)
+      target: x86_64-pc-windows-msvc  # Triple of target platform
+      channel: stable                 # Rust release channel (stable/beta/nightly/nightly-2018-12-01)
+    - platform: arm64
+      target: aarch64-pc-windows-msvc 
+      channel: stable
+matrix:
+  allow_failures:                     # Allows jobs with these variables to fail
+    - platform: arm64
+
+install:
+    - git submodule update --init
+    - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe  # Downloads Rustup-init 
+    - rustup-init -yv --default-toolchain %channel% --default-host %host%     # Installs Rust
+    - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%        # Adds Rust tools (Cargo, Rustup, etc.) to path
+    - rustc -vV                       # Prints Rust version
+    - cargo -vV                       # Prints Cargo version
+    - rustup target add %target%      # Adds target platform to Rust
+
+build_script:
+    - cargo build --release --target=%target%      # Builds file defined in Cargo.toml (default main.rs)
+
+test_script:
+    - cargo test --target=%target% --verbose       # Runs tests in "src" and "tests" folders
+#    - cargo bench --target=%target% --verbose      # Runs benchmarks in "src/lib.rs"
+
+artifacts:                          
+    - path: target\$(target)\release\*$(APPVEYOR_PROJECT_NAME)*.*     # Publishes all files from `cargo build/test/bench --release`
+      name: $(APPVEYOR_PROJECT_NAME)-$(platform)                      # Gives it a fancy name
+      
+deploy:
+  - provider: GitHub
+    artifact: $(APPVEYOR_PROJECT_NAME)-$(platform)
+    auth_token:
+      secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
+    prerelease: true
+    on:
+      appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ deploy:
   - provider: GitHub
     artifact: $(APPVEYOR_PROJECT_NAME)-$(platform)
     auth_token:
-      secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
+      secure: 'QCk1JOBFqqUAqrTFPYcCLDwYduLYArXmkJCkQAVHNjdUUU5SO0qRP8EnStJnD0OB'
     prerelease: true
     on:
       appveyor_repo_tag: true


### PR DESCRIPTION
Adds continuous integration with AppVeyor for automated Windows builds.

For optimal integration with GitHub, AppVeyor needs to be [enabled](https://github.com/marketplace/appveyor) on the GitHub Marketplace.

When enabled, AppVeyor publishes the artifacts with each build. When tagging a new (pre)release, AppVeyor will also upload libharsh.rlib and libharsh.d to GitHub, creating a nice release page [like this](https://github.com/EwoutH/harsh/releases/tag/0.0.1-test1).

To enable uploading to GitHub Releases, you need update this patch with your personal authentication token. You can generate one on https://github.com/settings/tokens/new (select `public_repo` as scope), and then encrypt it with https://ci.appveyor.com/tools/encrypt. Replace the current token on line 40 (after `secure:`) in the `appveyor.yml` file. 